### PR TITLE
Fix to get graphana 2.0 work for opentsdbM

### DIFF
--- a/public/app/panels/dashlist/module.js
+++ b/public/app/panels/dashlist/module.js
@@ -14,7 +14,7 @@ function (angular, app, _, config, PanelMeta) {
   module.directive('grafanaPanelDashlist', function() {
     return {
       controller: 'DashListPanelCtrl',
-      templateUrl: 'app/panels/dashlist/module.html',
+      templateUrl: 'app/panels/dashlist/module.html'
     };
   });
 
@@ -23,7 +23,7 @@ function (angular, app, _, config, PanelMeta) {
     $scope.panelMeta = new PanelMeta({
       panelName: 'Dashboard list',
       editIcon:  "fa fa-star",
-      fullscreen: true,
+      fullscreen: true
     });
 
     $scope.panelMeta.addEditorTab('Options', 'app/panels/dashlist/editor.html');

--- a/public/app/plugins/datasource/opentsdbM/datasource.js
+++ b/public/app/plugins/datasource/opentsdbM/datasource.js
@@ -79,8 +79,12 @@ function (angular, _, kbn) {
 
       metricLabel = (options.alias == null) ? md.expression : options.alias;
 
+		//The endpoints return values in string format, looking at datasource.js in opentsdb
+		//there seem to be an issue with dps as graph.js callPlot function is using jquery flot lib
+		//to render graph which is expecting datapoints to be in integer format. So multiplying key *1000
+		// will help in getting the data to be displayed in the panel.
       _.each(md.dps, function (v, k) {
-        dps.push([v, k]);
+        dps.push([v, k * 1000]);
       });
 
       return { target: metricLabel, datapoints: dps };


### PR DESCRIPTION
Tested grafana opentsdbM working with the following queries:

alias(difference(sum:1m-avg:turn.logsynclag.sourcelogs.value{host=app353,dc=sjc2},sum:1m-avg:turn.logsynclag.hdfslogs.value{host=app353,dc=sjc2}),sjc2)

sum(sum:proc.stat.cpu.percpu{cpu=1},sum:proc.stat.cpu.percpu{cpu=2})


Jira: TDB-111